### PR TITLE
add meeting notes 73

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A collection of learning materials on the Beam chain and Ream client.
 
 | №   | Date                          | Notes                           | Recordings                                |
 | --- | ----------------------------- | ------------------------------- | ----------------------------------------- |
+| 073 | May 26, 2026, 14:30-14:45 UTC | [Notes](./meeting-notes/073.md) | Not available                             |
 | 072 | May 19, 2026, 14:30-14:45 UTC | [Notes](./meeting-notes/072.md) | Not available                             |
 | 071 | May 12, 2026, 14:30-14:45 UTC | [Notes](./meeting-notes/071.md) | Not available                             |
 | 070 | May  5, 2026, 14:30-14:45 UTC | [Notes](./meeting-notes/070.md) | Not available                             |

--- a/meeting-notes/073.md
+++ b/meeting-notes/073.md
@@ -1,0 +1,51 @@
+# Ream Meeting #73 Recap
+
+## Overview
+
+This meeting focused on Ream client metrics and stability, leanMultisig performance, leanSpec test vectors and the fill pipeline, and Hive test coverage. The team worked through expanded client metrics and a leanMultisig crash with its interim workaround, new leanBench measurements indicating that devnet-5 proof splitting and re-aggregation remain over the slot budget and reopening the finalization-time tradeoff, fixes to the leanSpec production test vectors along with a substantial speedup to vector generation, and a decision to target devnet-5 for new aggregation and recursive aggregation test vectors
+
+On the testing side, Hive now pulls the latest leanSpec test assets automatically and an expanded two-subnet interop matrix is surfacing instability, alongside a discussion about keeping devnet-4 and devnet-5 alive longer to preserve a stable testing ground.
+
+## Development Progress
+
+### Ream client metrics and stability
+
+- **Client metrics batch**: Most of the metrics from leanMetrics have been added to the client; the fork-choice reorg metrics were skipped for now while the approach is worked out (Shariq).
+- **Missing aggregation-time metric**: The aggregation-time metric is still not visible on Partha's setup; the difference between his setup and the client will be diagnosed (Shariq).
+- **leanMultisig < 3-signer crash**: The client was crashing repeatedly on devnets, traced to leanMultisig panicking when aggregating fewer than three signers. The interim workaround skips aggregation in that case (and the panic is now caught and logged as an error), which has stopped the server crashes, but the proper fix is still being investigated and will land as a PR (Shariq).
+- **Additional metrics**: A few more metrics were implemented, with another in progress (Kayden).
+- **devnet-5 work split**: Some of the devnet-5 work was split between Shariq and Kayden after a call, and implementation is underway (Kayden).
+- **leanMultisig commit bump**: The client's leanMultisig commit was updated to the latest, which may have contributed to some of the errors seen initially (Kayden).
+
+### leanMultisig performance (leanBench)
+
+- **devnet-5 split/merge benchmarks**: New leanBench benchmarks cover the splitting and merging coming in devnet-5. Early numbers on a 32-core machine show splitting two merged aggregations takes about 3.8 seconds (already a full slot, and that is splitting alone), and merging an aggregation back into a recursive proof takes roughly 4.9 seconds more — about eight seconds for a full split-and-merge cycle (Unnawut).
+- **Finalization-time tradeoff**: Unless leanMultisig is optimized aggressively, an alternative worth weighing is a longer finalization time — for example extending from 3SF toward something like 6SF — which needs broader consideration (Unnawut).
+
+### leanSpec test vectors and fill pipeline
+
+- **Production test vector fix**: The leanSpec production test vectors (flagged by ethlambda) were failing because the scheme changed; this was fixed, along with some caching and download issues that had broken the pipeline (Unnawut).
+- **Fill parallelization fix**: After the devnet-5 PR, production vector generation had dropped to single-threaded and was taking five hours. The cause was a conflict where the Python runner spawned four workers for four cores while rayon inside the Rust side also split four more per worker, creating a four-by-four race for CPU time. Reducing rayon to one thread brought it back to about an hour, and further small optimization has it down to roughly 30–40 minutes (Unnawut).
+- **Aggregation test vectors**: There are currently no test vectors for aggregation, let alone recursive aggregation; adding these is the focus for the day (Unnawut).
+- **Target fork decision**: Since the spec's main branch is already on devnet-5 with substantial leanMultisig API changes, the team agreed to target devnet-5 for the new aggregation and recursive aggregation test vectors. Existing vectors for earlier devnets can still be retrieved from the repo history rather than maintained on a branch (Unnawut, Kolby, Shariq).
+
+### Hive testing
+
+- **Latest test assets pulled automatically**: Hive tests now pull the latest test assets generated on the leanSpec repo each time, rather than using a one-off snapshot stored in the Ream repo, so Hive is always testing against the newest vectors (Kolby).
+- **devnet-3 removal and dual-fork runs**: devnet-3 support is being removed today and devnet-5-specific flags added to Hive, with both devnet-4 and devnet-5 run until devnet-4 is fully retired; the legacy client will then be bumped to the next fork (Kolby).
+- **Two-subnet interrupt tests**: The two-subnet client interrupt tests and their visualization were finished and added to Hive, with a large number failing — highlighting significant instability once more than one subnet is running (Derek).
+- **Interop aggregator coverage**: The interop test now assigns the aggregator role to both the minority and a majority client rather than only the minority, producing two matrix grids that have already exposed client-pair differences in each aggregator configuration (Derek).
+- **In-progress run status bar**: Work started on what should be the last visual addition to the Hive Lean latest page — a status bar showing the most recent run in progress. This needs changes to how Hive runs, since the log generated at the start of a run carries no digest of what is intended to run; the least intrusive approach is being explored (Derek).
+- **Sync test fix**: The Hive sync tests had stopped starting entirely after recent leanSpec changes; this was fixed and a PR is up (Derek).
+
+### devnet strategy
+
+- **Keep devnet-4 and devnet-5 alive longer**: There was support for keeping both devnet-4 and devnet-5 running for longer, with devnet-4 in particular kept alive as a more stable base. devnet-4 already brought more instability than the stable devnet-3, and devnet-5's computational requirements are expected to be higher still, so a stable ground for testing PQ signature work remains valuable (Shariq).
+
+## Next Steps
+
+- **Shariq**: File the PR for the leanMultisig <3-signer crash and work out the proper fix, and diagnose why the aggregation-time metric is not visible on Partha's setup.
+- **Kayden**: Continue implementing client metrics and progress the split devnet-5 work.
+- **Kolby**: Remove devnet-3 support, add devnet-5 flags to Hive, and run both devnet-4 and devnet-5 until devnet-4 is retired.
+- **Derek**: Continue the in-progress-run status bar visualization to finish off the Hive Lean latest page.
+- **Unnawut**: Add aggregation and recursive aggregation test vectors targeting devnet-5.


### PR DESCRIPTION
Adds the recap for Ream Meeting #73 (May 26, 2026) and a matching row at the top of the Meeting Notes table in the README.